### PR TITLE
Make start required arguments more explicit

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -84,8 +84,16 @@ fn main() -> Result<()> {
         .subcommand(
             SubCommand::with_name("start")
                 .about("starts a new activity")
-                .arg(&arg_description)
-                .arg(&arg_project)
+                .arg(
+                    arg_project
+                        .clone()
+                        .required(true)
+                )
+                .arg(
+                    arg_description
+                        .clone()
+                        .required(true)
+                )
                 .arg(&arg_time),
         )
         .subcommand(


### PR DESCRIPTION
### Problem Description

One small papercut while starting to use this tools was what arguments were really required to "start" a new task.

The current help for `bartib start` does not show any required arguments or flags:

```
bartib start -h
bartib-start
starts a new activity

USAGE:
    bartib start [OPTIONS]

FLAGS:
    -h, --help    Prints help information

OPTIONS:
    -d, --description <DESCRIPTION>    the description of the new activity
    -p, --project <PROJECT>            the project to which the new activity belongs
    -t, --time <TIME>                  the time for changing the activity status (HH:MM)
```

However, when I attempt to use as is, it of course needs some data to actually start an activity:

```
bartib start -d "test descr"
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', ...
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


### Possible Solutions

Of course, there are multiple ways to help with this. Here are a few I thought of:
1. make description and project flags explicit through clap args
2. do input validation in the controller, likely around here: https://github.com/nikolassv/bartib/blob/master/src/controller/manipulation.rs#L29-L33
3. do input validation in `Activity::start` https://github.com/nikolassv/bartib/blob/master/src/data/activity.rs#L26
4. make only `project` arg required, default `description` to empty string (or other design related change)

I'm sure there are other ways but (1) seemed like the easiest so I sent a quick PR. 

### Testing

Validating new args have expected help after `cargo build --release`


`start` command help makes required args more explicit
```
./target/release/bartib start -h
bartib-start
starts a new activity

USAGE:
    bartib start [OPTIONS] --description <DESCRIPTION> --project <PROJECT>

FLAGS:
    -h, --help    Prints help information

OPTIONS:
    -d, --description <DESCRIPTION>    the description of the new activity
    -p, --project <PROJECT>            the project to which the new activity belongs
    -t, --time <TIME>                  the time for changing the activity status (HH:MM)

```

`continue` command args are unchanged

```
./target/release/bartib continue -h
bartib-continue
continues a previous activity

USAGE:
    bartib continue [OPTIONS] [NUMBER]

FLAGS:
    -h, --help    Prints help information

OPTIONS:
    -d, --description <DESCRIPTION>    the description of the new activity
    -p, --project <PROJECT>            the project to which the new activity belongs
    -t, --time <TIME>                  the time for changing the activity status (HH:MM)

ARGS:
    <NUMBER>    the number of the activity to continue (see subcommand `last`) [default: 0]

```

Validating required flag shows more helpful error message:

Error 1: no project provided

```
./target/release/bartib start -d "test"
error: The following required arguments were not provided:
    --project <PROJECT>

USAGE:
    bartib start [OPTIONS] --description <DESCRIPTION> --project <PROJECT>

For more information try --help
```

Error 2: no description provided
```
./target/release/bartib start -p "test"
error: The following required arguments were not provided:
    --description <DESCRIPTION>

USAGE:
    bartib start [OPTIONS] --description <DESCRIPTION> --project <PROJECT>

For more information try --help
```

Happy case: all args provided
```
./target/release/bartib start -p "test project" -d "test description"
Stopped activity: "write general SOP for all application levers" (availability lever SOP) started at 2021-11-16 18:17 (05m)
Started activity: "test description" (test project) at 2021-11-16 18:22
```