### PR TITLE
Add an option to only print current projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ bartib list --project "The most exciting project"    # list activities for a giv
 ```bash
 bartib current    # show currently running activity
 bartib projects    # list all projects ever used
+bartib projects -c # show current project only
 
 bartib edit   # open the activity log in the editor you have defined in your `EDITOR` environment variable
 bartib edit -e vim    # open the activity log in a given editor

--- a/src/controller/list.rs
+++ b/src/controller/list.rs
@@ -6,10 +6,11 @@ use crate::data::getter;
 use crate::view::list;
 
 // lists all currently runninng activities.
-pub fn list_running(file_name: &str, only_project: bool) -> Result<()> {
+pub fn list_running(file_name: &str) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
     let running_activities = getter::get_running_activities(&file_content);
-    list::list_running_activities(&running_activities, only_project);
+
+    list::list_running_activities(&running_activities);
 
     Ok(())
 }
@@ -69,10 +70,11 @@ pub fn check(file_name: &str) -> Result<()> {
 }
 
 // lists all projects
-pub fn list_projects(file_name: &str) -> Result<()> {
+pub fn list_projects(file_name: &str, current: bool) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
 
     let mut all_projects: Vec<&String> = getter::get_activities(&file_content)
+        .filter(|activity| !(current && activity.is_stopped()))
         .map(|activity| &activity.project)
         .collect();
 

--- a/src/controller/list.rs
+++ b/src/controller/list.rs
@@ -6,10 +6,10 @@ use crate::data::getter;
 use crate::view::list;
 
 // lists all currently runninng activities.
-pub fn list_running(file_name: &str) -> Result<()> {
+pub fn list_running(file_name: &str, only_project: bool) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
     let running_activities = getter::get_running_activities(&file_content);
-    list::list_running_activities(&running_activities);
+    list::list_running_activities(&running_activities, only_project);
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,14 @@ fn main() -> Result<()> {
                 .about("cancels all currently running activities")
         )
         .subcommand(
-            SubCommand::with_name("current").about("lists all currently running activities"),
+            SubCommand::with_name("current")
+                .about("lists all currently running activities")
+                .arg(
+                    Arg::with_name("compact_mode")
+                    .long("compact")
+                    .short("c")
+                    .help("Compact mode. Report only projects names. Nothing if no current project. Useful for shell plugins")
+                )
         )
         .subcommand(
             SubCommand::with_name("list")
@@ -257,7 +264,7 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
             bartib::controller::manipulation::stop(file_name, time)
         }
         ("cancel", Some(_)) => bartib::controller::manipulation::cancel(file_name),
-        ("current", Some(_)) => bartib::controller::list::list_running(file_name),
+        ("current", Some(sub_m)) => bartib::controller::list::list_running(file_name, sub_m.is_present("compact_mode") ),
         ("list", Some(sub_m)) => {
             let filter = create_filter_for_arguments(sub_m);
             let do_group_activities = !sub_m.is_present("no_grouping") && filter.date.is_none();

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,12 +138,6 @@ fn main() -> Result<()> {
         .subcommand(
             SubCommand::with_name("current")
                 .about("lists all currently running activities")
-                .arg(
-                    Arg::with_name("compact_mode")
-                    .long("compact")
-                    .short("c")
-                    .help("Compact mode. Report only projects names. Nothing if no current project. Useful for shell plugins")
-                )
         )
         .subcommand(
             SubCommand::with_name("list")
@@ -213,7 +207,18 @@ fn main() -> Result<()> {
                         .default_value("10")
                 )
         )
-        .subcommand(SubCommand::with_name("projects").about("list all projects"))
+        .subcommand(
+            SubCommand::with_name("projects")
+                .about("list all projects")
+                .arg(
+                    Arg::with_name("current")
+                        .short("c")
+                        .long("current")
+                        .help("prints currently running projects only")
+                        .takes_value(false)
+                        .required(false)
+                )
+        )
         .subcommand(
             SubCommand::with_name("edit")
                 .about("opens the activity log in an editor")
@@ -264,7 +269,7 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
             bartib::controller::manipulation::stop(file_name, time)
         }
         ("cancel", Some(_)) => bartib::controller::manipulation::cancel(file_name),
-        ("current", Some(sub_m)) => bartib::controller::list::list_running(file_name, sub_m.is_present("compact_mode") ),
+        ("current", Some(_)) => bartib::controller::list::list_running(file_name),
         ("list", Some(sub_m)) => {
             let filter = create_filter_for_arguments(sub_m);
             let do_group_activities = !sub_m.is_present("no_grouping") && filter.date.is_none();
@@ -274,7 +279,7 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
             let filter = create_filter_for_arguments(sub_m);
             bartib::controller::report::show_report(file_name, filter)
         }
-        ("projects", Some(_)) => bartib::controller::list::list_projects(file_name),
+        ("projects", Some(sub_m)) => bartib::controller::list::list_projects(file_name, sub_m.is_present("current")),
         ("last", Some(sub_m)) => {
             let number = get_number_argument_or_ignore(
                 sub_m.value_of("number"),

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -62,18 +62,8 @@ fn create_activites_group(title: &str, activities: &[&activity::Activity]) -> ta
 }
 
 // displays a table with running activities (no end time)
-pub fn list_running_activities(running_activities: &[&activity::Activity], compact_mode: bool) {
-    if compact_mode {
-        print!("{}",
-            running_activities
-                .iter()
-                .map(|a|a.project.clone())
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
-        return
-    }
-    if running_activities.is_empty() {
+pub fn list_running_activities(activities: &[&activity::Activity]) {
+    if activities.is_empty() {
         println!("No Activity is currently running");
     } else {
         let mut activity_table = table::Table::new(vec![
@@ -83,7 +73,7 @@ pub fn list_running_activities(running_activities: &[&activity::Activity], compa
             table::Column{ label: "Duration".to_string(), wrap: table::Wrap::NoWrap },
         ]);
 
-        running_activities
+        activities
             .iter()
             .map(|activity| {
                 table::Row::new(vec![

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -62,7 +62,17 @@ fn create_activites_group(title: &str, activities: &[&activity::Activity]) -> ta
 }
 
 // displays a table with running activities (no end time)
-pub fn list_running_activities(running_activities: &[&activity::Activity]) {
+pub fn list_running_activities(running_activities: &[&activity::Activity], compact_mode: bool) {
+    if compact_mode {
+        print!("{}",
+            running_activities
+                .iter()
+                .map(|a|a.project.clone())
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        return
+    }
     if running_activities.is_empty() {
         println!("No Activity is currently running");
     } else {


### PR DESCRIPTION
First of all thanks for the great tool!

I use oh-my-zsh with a bunch of plugins and I think this will be very nice to see the current running project without having to type `bartib current`. This helps with remembering that I need to switch projects.
