### PR TITLE
Sanity check for activity start- and endtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,4 +274,5 @@ bartib edit   # open the activity log in the editor you have defined in your `ED
 bartib edit -e vim    # open the activity log in a given editor
 
 bartib check    # check your activity log for invalid lines
+bartib sanity    # check for activities with logical errors (e.g activities with negative duration)
 ```

--- a/src/controller/list.rs
+++ b/src/controller/list.rs
@@ -18,7 +18,11 @@ pub fn list_running(file_name: &str) -> Result<()> {
 // lists tracked activities
 //
 // the activities will be ordered chronologically.
-pub fn list(file_name: &str, filter: getter::ActivityFilter, do_group_activities: bool) -> Result<()> {
+pub fn list(
+    file_name: &str,
+    filter: getter::ActivityFilter,
+    do_group_activities: bool,
+) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
     let activities = getter::get_activities(&file_content);
     let mut filtered_activities: Vec<&activity::Activity> =
@@ -26,18 +30,17 @@ pub fn list(file_name: &str, filter: getter::ActivityFilter, do_group_activities
 
     filtered_activities.sort_by_key(|activity| activity.start);
 
-    let first_element = filtered_activities.len().saturating_sub(filter.number_of_activities.unwrap_or(filtered_activities.len()));
+    let first_element = filtered_activities.len().saturating_sub(
+        filter
+            .number_of_activities
+            .unwrap_or(filtered_activities.len()),
+    );
 
     if do_group_activities {
-        list::list_activities_grouped_by_date(
-            &filtered_activities[first_element..],
-        );
+        list::list_activities_grouped_by_date(&filtered_activities[first_element..]);
     } else {
         let with_start_dates = filter.date.is_none();
-        list::list_activities(
-            &filtered_activities[first_element..],
-            with_start_dates,
-        );
+        list::list_activities(&filtered_activities[first_element..], with_start_dates);
     }
 
     Ok(())
@@ -47,7 +50,8 @@ pub fn list(file_name: &str, filter: getter::ActivityFilter, do_group_activities
 pub fn check(file_name: &str) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
 
-    let number_of_errors = file_content.iter()
+    let number_of_errors = file_content
+        .iter()
         .filter(|line| line.activity.is_err())
         .count();
 
@@ -58,11 +62,17 @@ pub fn check(file_name: &str) -> Result<()> {
 
     println!("Found {} line(s) with parsing errors", number_of_errors);
 
-    file_content.iter()
+    file_content
+        .iter()
         .filter(|line| line.activity.is_err() && line.plaintext.is_some())
         .for_each(|line| {
             if let Err(e) = &line.activity {
-                println!("\n{}\n  -> {} (Line: {})", line.plaintext.as_ref().unwrap(), e.to_string(), line.line_number.unwrap_or(0));
+                println!(
+                    "\n{}\n  -> {} (Line: {})",
+                    line.plaintext.as_ref().unwrap(),
+                    e.to_string(),
+                    line.line_number.unwrap_or(0)
+                );
             }
         });
 
@@ -92,7 +102,8 @@ pub fn list_projects(file_name: &str, current: bool) -> Result<()> {
 pub fn list_last_activities(file_name: &str, number: usize) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
 
-    let descriptions_and_projects : Vec<(&String, &String)> = getter::get_descriptions_and_projects(&file_content);
+    let descriptions_and_projects: Vec<(&String, &String)> =
+        getter::get_descriptions_and_projects(&file_content);
     let first_element = descriptions_and_projects.len().saturating_sub(number);
 
     list::list_descriptions_and_projects(&descriptions_and_projects[first_element..]);

--- a/src/controller/list.rs
+++ b/src/controller/list.rs
@@ -72,11 +72,11 @@ pub fn sanity_check(file_name: &str) -> Result<()> {
         if let Some(e) = last_end {
             if let Some(this_end) = activity.end {
                 if this_end > e {
-                    last_end = Some(this_end.clone());
+                    last_end = Some(this_end);
                 }
             }
         } else {
-            last_end = activity.end.clone();
+            last_end = activity.end;
         }
     }
 
@@ -102,10 +102,10 @@ fn check_sanity(last_end: Option<NaiveDateTime>, activity: &Activity, line_numbe
     }
 
     if !sane {
-        print_activity_with_line(&activity, line_number.unwrap_or(0));
+        print_activity_with_line(activity, line_number.unwrap_or(0));
     }
 
-    return sane;
+    sane
 }
 
 fn print_activity_with_line(activity: &Activity, line_number: usize) {
@@ -114,7 +114,7 @@ fn print_activity_with_line(activity: &Activity, line_number: usize) {
              activity.start.format(conf::FORMAT_DATETIME),
              activity.end
                  .map(|end| end.format(conf::FORMAT_DATETIME).to_string())
-                 .unwrap_or(String::from("--")),
+                 .unwrap_or_else(|| String::from("--")),
              line_number
     )
 }

--- a/src/controller/list.rs
+++ b/src/controller/list.rs
@@ -70,7 +70,7 @@ pub fn check(file_name: &str) -> Result<()> {
                 println!(
                     "\n{}\n  -> {} (Line: {})",
                     line.plaintext.as_ref().unwrap(),
-                    e.to_string(),
+                    e,
                     line.line_number.unwrap_or(0)
                 );
             }

--- a/src/data/activity.rs
+++ b/src/data/activity.rs
@@ -52,16 +52,16 @@ impl Activity {
         }
     }
 
-    pub fn parse_with_preceeding(
+    pub fn parse_with_preceding(
         plaintext: &str,
-        preceeding: Option<&Activity>,
+        preceding: Option<&Activity>,
     ) -> Result<Activity, ActivityError> {
         let activity = Activity::from_str(plaintext)?;
 
-        if let Some(preceeding) = preceeding {
-            match preceeding.end {
-                Some(preceeding_end) => {
-                    if preceeding_end > activity.start {
+        if let Some(preceding) = preceding {
+            match preceding.end {
+                Some(preceding_end) => {
+                    if preceding_end > activity.start {
                         return Err(ActivityError::InvalidOrderError);
                     }
                 }
@@ -346,23 +346,23 @@ mod tests {
     }
 
     #[test]
-    fn parse_with_preceeding_errors() {
+    fn parse_with_preceding_errors() {
         let p = Activity::from_str("2022-03-31 21:31 - 2022-03-31 21:35 | project").unwrap();
-        let t = Activity::parse_with_preceeding("2022-03-31 21:30 | project", Some(&p));
+        let t = Activity::parse_with_preceding("2022-03-31 21:30 | project", Some(&p));
         assert!(matches!(t, Err(ActivityError::InvalidOrderError)));
 
         let p = Activity::from_str("2022-03-31 21:31 | project").unwrap();
-        let t = Activity::parse_with_preceeding("2022-03-31 21:30 | project", Some(&p));
+        let t = Activity::parse_with_preceding("2022-03-31 21:30 | project", Some(&p));
         assert!(matches!(t, Err(ActivityError::InvalidOrderError)));
     }
 
     #[test]
-    fn parse_with_preceeding_ok() {
-        let t = Activity::parse_with_preceeding("2022-03-31 21:30 | project", None);
+    fn parse_with_preceding_ok() {
+        let t = Activity::parse_with_preceding("2022-03-31 21:30 | project", None);
         assert!(t.is_ok());
 
         let p = Activity::from_str("2022-03-31 21:31 - 2022-03-31 21:35 | project").unwrap();
-        let t = Activity::parse_with_preceeding("2022-03-31 21:35 | project", Some(&p));
+        let t = Activity::parse_with_preceding("2022-03-31 21:35 | project", Some(&p));
         assert!(t.is_ok());
     }
 }

--- a/src/data/bartib_file.rs
+++ b/src/data/bartib_file.rs
@@ -27,13 +27,13 @@ pub struct Line {
 
 impl Line {
     // creates a new line struct from plaintext
-    pub fn new(plaintext: &str, line_number: usize, preceeding_line: Option<&Line>) -> Line {
-        let preceeding_activity = preceeding_line.and_then(|line| line.activity.as_ref().ok());
+    pub fn new(plaintext: &str, line_number: usize, preceding_line: Option<&Line>) -> Line {
+        let preceding_activity = preceding_line.and_then(|line| line.activity.as_ref().ok());
 
         Line {
             plaintext: Some(plaintext.trim().to_string()),
             line_number: Some(line_number),
-            activity: activity::Activity::parse_with_preceeding(plaintext, preceeding_activity),
+            activity: activity::Activity::parse_with_preceding(plaintext, preceding_activity),
             status: LineStatus::Unchanged,
         }
     }

--- a/src/data/bartib_file.rs
+++ b/src/data/bartib_file.rs
@@ -28,9 +28,7 @@ pub struct Line {
 impl Line {
     // creates a new line struct from plaintext
     pub fn new(plaintext: &str, line_number: usize, preceeding_line: Option<&Line>) -> Line {
-        let preceeding_activity = preceeding_line
-            .map(|line| line.activity.as_ref().ok())
-            .flatten();
+        let preceeding_activity = preceeding_line.and_then(|line| line.activity.as_ref().ok());
 
         Line {
             plaintext: Some(plaintext.trim().to_string()),

--- a/src/data/getter.rs
+++ b/src/data/getter.rs
@@ -1,34 +1,38 @@
-use std::collections::HashSet;
 use chrono::{naive, NaiveDate};
+use std::collections::HashSet;
 
 use crate::data::activity;
-use crate::data::bartib_file;
 use crate::data::activity::Activity;
+use crate::data::bartib_file;
 
 pub struct ActivityFilter<'a> {
     pub number_of_activities: Option<usize>,
     pub from_date: Option<NaiveDate>,
     pub to_date: Option<NaiveDate>,
     pub date: Option<NaiveDate>,
-    pub project: Option<&'a str>
+    pub project: Option<&'a str>,
 }
 
-pub fn get_descriptions_and_projects(file_content: &[bartib_file::Line]) -> Vec<(&String, &String)> {
-    let mut activities : Vec<&activity::Activity> = get_activities(file_content).collect();
+pub fn get_descriptions_and_projects(
+    file_content: &[bartib_file::Line],
+) -> Vec<(&String, &String)> {
+    let mut activities: Vec<&activity::Activity> = get_activities(file_content).collect();
     get_descriptions_and_projects_from_activities(&mut activities)
 }
 
-fn get_descriptions_and_projects_from_activities<'a>(activities: &mut [&'a Activity]) -> Vec<(&'a String, &'a String)> {
+fn get_descriptions_and_projects_from_activities<'a>(
+    activities: &mut [&'a Activity],
+) -> Vec<(&'a String, &'a String)> {
     activities.sort_by_key(|activity| activity.start);
 
     /* each activity should be placed in the list in the descending order of when it had been
-        started last. To achieve this we reverse the order of the activities before we extract the
-        set of descriptions and activities. Afterwards we also reverse the list of descriptions and
-        activities.
+       started last. To achieve this we reverse the order of the activities before we extract the
+       set of descriptions and activities. Afterwards we also reverse the list of descriptions and
+       activities.
 
-        e.g. if tasks have been started in this order: a, b, c, a, c the list of descriptions and
-            activities should have this order: b, a, c
-     */
+       e.g. if tasks have been started in this order: a, b, c, a, c the list of descriptions and
+           activities should have this order: b, a, c
+    */
     activities.reverse();
 
     let mut known_descriptions_and_projects: HashSet<(&String, &String)> = HashSet::new();
@@ -51,11 +55,21 @@ pub fn get_running_activities(file_content: &[bartib_file::Line]) -> Vec<&activi
         .collect()
 }
 
-pub fn get_activities(file_content: &[bartib_file::Line]) -> impl Iterator<Item = &activity::Activity> {
+pub fn get_activities(
+    file_content: &[bartib_file::Line],
+) -> impl Iterator<Item = &activity::Activity> {
     file_content
         .iter()
-        .map(|line| line.activity.as_ref())
-        .filter_map(|activity_result| activity_result.ok())
+        .filter_map(|line: &bartib_file::Line| match &line.activity {
+            Ok(activity) => Some(activity),
+            Err(_) => {
+                println!(
+                    "Warning: Ignoring line {}. Please see `bartib check` for further information",
+                    line.line_number.unwrap_or(0),
+                );
+                None
+            }
+        })
 }
 
 pub fn filter_activities<'a>(
@@ -74,17 +88,30 @@ pub fn filter_activities<'a>(
     }
 
     activities
-        .filter(move |activity| {activity.start.date() >= from_date && activity.start.date() <= to_date})
-        .filter(move |activity| filter.project.map(|p| activity.project == *p).unwrap_or(true))
+        .filter(move |activity| {
+            activity.start.date() >= from_date && activity.start.date() <= to_date
+        })
+        .filter(move |activity| {
+            filter
+                .project
+                .map(|p| activity.project == *p)
+                .unwrap_or(true)
+        })
 }
 
 pub fn get_last_activity_by_end(file_content: &[bartib_file::Line]) -> Option<&activity::Activity> {
     get_activities(file_content)
         .filter(|activity| activity.is_stopped())
-        .max_by_key(|activity| activity.end.unwrap_or_else(||naive::MIN_DATE.and_hms(0, 0, 0)))
+        .max_by_key(|activity| {
+            activity
+                .end
+                .unwrap_or_else(|| naive::MIN_DATE.and_hms(0, 0, 0))
+        })
 }
 
-pub fn get_last_activity_by_start(file_content: &[bartib_file::Line]) -> Option<&activity::Activity> {
+pub fn get_last_activity_by_start(
+    file_content: &[bartib_file::Line],
+) -> Option<&activity::Activity> {
     get_activities(file_content).max_by_key(|activity| activity.start)
 }
 
@@ -99,11 +126,18 @@ mod tests {
         let a3 = activity::Activity::start("p2".to_string(), "d1".to_string(), None);
         let mut activities = vec![&a1, &a2, &a3];
 
-        let descriptions_and_projects = get_descriptions_and_projects_from_activities(&mut activities);
+        let descriptions_and_projects =
+            get_descriptions_and_projects_from_activities(&mut activities);
 
         assert_eq!(descriptions_and_projects.len(), 2);
-        assert_eq!(*descriptions_and_projects.get(0).unwrap(), (&"d1".to_string(), &"p1".to_string()));
-        assert_eq!(*descriptions_and_projects.get(1).unwrap(), (&"d1".to_string(), &"p2".to_string()));
+        assert_eq!(
+            *descriptions_and_projects.get(0).unwrap(),
+            (&"d1".to_string(), &"p1".to_string())
+        );
+        assert_eq!(
+            *descriptions_and_projects.get(1).unwrap(),
+            (&"d1".to_string(), &"p2".to_string())
+        );
     }
 
     #[test]
@@ -113,10 +147,17 @@ mod tests {
         let a3 = activity::Activity::start("p1".to_string(), "d1".to_string(), None);
         let mut activities = vec![&a1, &a2, &a3];
 
-        let descriptions_and_projects = get_descriptions_and_projects_from_activities(&mut activities);
+        let descriptions_and_projects =
+            get_descriptions_and_projects_from_activities(&mut activities);
 
         assert_eq!(descriptions_and_projects.len(), 2);
-        assert_eq!(*descriptions_and_projects.get(0).unwrap(), (&"d1".to_string(), &"p2".to_string()));
-        assert_eq!(*descriptions_and_projects.get(1).unwrap(), (&"d1".to_string(), &"p1".to_string()));
+        assert_eq!(
+            *descriptions_and_projects.get(0).unwrap(),
+            (&"d1".to_string(), &"p2".to_string())
+        );
+        assert_eq!(
+            *descriptions_and_projects.get(1).unwrap(),
+            (&"d1".to_string(), &"p1".to_string())
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -232,6 +232,7 @@ fn main() -> Result<()> {
                 ),
         )
         .subcommand(SubCommand::with_name("check").about("checks file and reports parsing errors"))
+        .subcommand(SubCommand::with_name("sanity").about("checks sanity of bartib log"))
         .get_matches();
 
     let file_name = matches.value_of("file")
@@ -292,12 +293,13 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
             bartib::controller::manipulation::start_editor(file_name, optional_editor_command)
         }
         ("check", Some(_)) => bartib::controller::list::check(file_name),
+        ("sanity", Some(_)) => bartib::controller::list::sanity_check(file_name),
         _ => bail!("Unknown command"),
     }
 }
 
 fn create_filter_for_arguments<'a>(sub_m: &'a ArgMatches) -> ActivityFilter<'a> {
-    let mut filter = bartib::data::getter::ActivityFilter {
+    let mut filter = ActivityFilter {
         number_of_activities: get_number_argument_or_ignore(
             sub_m.value_of("number"),
             "-n/--number",

--- a/src/view/format_util.rs
+++ b/src/view/format_util.rs
@@ -4,7 +4,7 @@ pub fn format_duration(duration: &Duration) -> String {
     let mut duration_string = String::new();
 
     if duration.num_hours() > 0 {
-        duration_string.push_str(&format!("{}h ", duration.num_hours().to_string()));
+        duration_string.push_str(&format!("{}h ", duration.num_hours()));
     }
 
     if duration.num_minutes() > 0 {

--- a/src/view/report.rs
+++ b/src/view/report.rs
@@ -157,9 +157,7 @@ fn group_activities_by_description<'a>(activities: &'a [&'a activity::Activity])
 
 fn get_longest_line(project_map: &ProjectMap) -> Option<usize> {
     let longest_project_line = project_map.keys().map(|p| p.chars().count()).max();
-    let longest_activity_line = project_map.values()
-        .map(|(a, _d)| a)
-        .flatten()
+    let longest_activity_line = project_map.values().flat_map(|(a, _d)| a)
         .map(|a| a.description.chars().count() + conf::REPORT_INDENTATION).max();
     get_max_option(longest_project_line, longest_activity_line)
 }
@@ -169,9 +167,7 @@ fn get_longest_duration_string(report: &Report) -> Option<usize> {
         .map(|(_a, d)| format_util::format_duration(d))
         .map(|s| s.chars().count())
         .max();
-    let longest_activity_duration = report.project_map.values()
-        .map(|(a, _d)| a)
-        .flatten()
+    let longest_activity_duration = report.project_map.values().flat_map(|(a, _d)| a)
         .map(|a| format_util::format_duration(&a.get_duration()))
         .map(|s| s.chars().count())
         .max();


### PR DESCRIPTION
Hello Stranger from the internet,

with this pull request I propose a sanity check for the start- and endtimes of activities.

It checks for two things:

1. The endtime of an activity may not precede the starttime.
2. An activity may not start before the previous one ended.

Errors are reported in `bartib check`. Additionally a warning is printed whenever the list of activies is parsed.

Big thanks for the project und bis Morgen !