### PR TITLE
Improve fish completions

### DIFF
--- a/misc/bartib.fish
+++ b/misc/bartib.fish
@@ -32,12 +32,19 @@ end
 
 function __fish_complete_bartib_numbers
     set -l output (bartib last -n 100 2>/dev/null)
-    string match -r "\[(\d)\]" -g $output
+
+    set -l description_and_project (string match -r '(\\e\[4mDescription.*)(\\e\[4mProject.*)' -g $output)
+    set -l description_length (math (string length $description_and_project[1]) - 9)
+    set -l project_length (math (string length $description_and_project[2]) - 8)
+    string trim --right (string match -r '(\d\t.*)' -g (string replace -r (echo "\[(\d)\] ([[:ascii:]]{0,$description_length})[^[:ascii:]]*([[:ascii:]]{0,$project_length}).*") '$1\t$3->$2' $output))
 end
 
 function __fish_complete_bartib_descriptions
-    set -l output (tail -n 100 $BARTIB_FILE)
-    string match -r ".*\|\s.*\|\s(.*)" -g $output
+    set -l output (bartib last -n 100 2>/dev/null)
+
+    set -l description_match (string match -r '(\\e\[4mDescription.*)' -g $output)
+    set -l description_length (math (string length $description_match) - 9)
+    string replace -r (echo "\[(\d)\] ([[:ascii:]]{0,$description_length}).*") '$2' (string match -r '\[\d\].*' $output)
 end
 
 function __is_last_argument


### PR DESCRIPTION
Hi, I've updated some of the completions from my last PR:

- Refactored some parts of the fish completions such that they now do not use `cat` anymore (some users may have overwritten or aliased the `cat` command, breaking the old version). Instead the "description search" now uses the `bartib last` command to find the descriptions
- In addition to that, I also made it such that the completion for the `continue` command now shows to which project and description the number belongs (see the attached image)

![Screenshot from 2023-05-04 12-54-51](https://user-images.githubusercontent.com/44158679/236184692-0e51d071-0840-4c91-865a-51154f887417.png)
