### PR TITLE
feat: added `status` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Subcommand `status` to display the total duration of activities today, in the current week and in the current month (thanks to [@airenas](https://github.com/airenas))
+
 ## [1.1.0] - 2024-02-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bartib"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/src/controller/mod.rs
+++ b/src/controller/mod.rs
@@ -1,3 +1,4 @@
 pub mod list;
 pub mod manipulation;
 pub mod report;
+pub mod status;

--- a/src/controller/status.rs
+++ b/src/controller/status.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use chrono::Local;
 
 use crate::data::activity;
 use crate::data::activity::Activity;
@@ -26,6 +27,8 @@ pub fn show_status(
 
     filtered_activities.sort_by_key(|activity| activity.start);
 
+    let now = Local::now().naive_local();
+
     let current: Option<&Activity> = filtered_activities
         .clone()
         .into_iter()
@@ -36,20 +39,20 @@ pub fn show_status(
     let today = filtered_activities
         .clone()
         .into_iter()
-        .filter(Filters::today())
+        .filter(Filters::today(now.date()))
         .map(|f| f.get_duration())
         .sum();
 
     let current_week = filtered_activities
         .clone()
         .into_iter()
-        .filter(Filters::current_week())
+        .filter(Filters::current_week(now.date()))
         .map(|f| f.get_duration())
         .sum();
 
     let current_month = filtered_activities
         .into_iter()
-        .filter(Filters::current_month())
+        .filter(Filters::current_month(now.date()))
         .map(|f| f.get_duration())
         .sum();
 

--- a/src/controller/status.rs
+++ b/src/controller/status.rs
@@ -6,13 +6,13 @@ use crate::data::bartib_file;
 use crate::data::filter::Filters;
 use crate::data::getter;
 use crate::data::processor;
-use crate::view::status;
-use crate::view::status::StatusReportData;
+use crate::data::processor::StatusReportData;
 
 pub fn show_status(
     file_name: &str,
     filter: getter::ActivityFilter,
     processors: processor::ProcessorList,
+    writer: &dyn processor::StatusReportWriter,
 ) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
     let activities: Vec<&Activity> = getter::get_activities(&file_content).collect();
@@ -53,13 +53,12 @@ pub fn show_status(
         .map(|f| f.get_duration())
         .sum();
 
-    status::show(StatusReportData {
+    let status_report_data = StatusReportData {
         activity: current,
         today,
         current_week,
         current_month,
         project: filter.project,
-    });
-
-    Ok(())
+    };
+    writer.process(&status_report_data)
 }

--- a/src/controller/status.rs
+++ b/src/controller/status.rs
@@ -1,0 +1,65 @@
+use anyhow::Result;
+
+use crate::data::activity;
+use crate::data::activity::Activity;
+use crate::data::bartib_file;
+use crate::data::filter::Filters;
+use crate::data::getter;
+use crate::data::processor;
+use crate::view::status;
+use crate::view::status::StatusReportData;
+
+pub fn show_status(
+    file_name: &str,
+    filter: getter::ActivityFilter,
+    processors: processor::ProcessorList,
+) -> Result<()> {
+    let file_content = bartib_file::get_file_content(file_name)?;
+    let activities: Vec<&Activity> = getter::get_activities(&file_content).collect();
+
+    let processed_activities_bind: Vec<activity::Activity> =
+        processor::process_activities(activities, processors);
+    let processed_activities: Vec<&activity::Activity> = processed_activities_bind.iter().collect();
+
+    let mut filtered_activities: Vec<&activity::Activity> =
+        getter::filter_activities(processed_activities, &filter);
+
+    filtered_activities.sort_by_key(|activity| activity.start);
+
+    let current: Option<&Activity> = filtered_activities
+        .clone()
+        .into_iter()
+        .filter(Filters::active)
+        .take(1)
+        .last();
+
+    let today = filtered_activities
+        .clone()
+        .into_iter()
+        .filter(Filters::today())
+        .map(|f| f.get_duration())
+        .sum();
+
+    let current_week = filtered_activities
+        .clone()
+        .into_iter()
+        .filter(Filters::current_week())
+        .map(|f| f.get_duration())
+        .sum();
+
+    let current_month = filtered_activities
+        .into_iter()
+        .filter(Filters::current_month())
+        .map(|f| f.get_duration())
+        .sum();
+
+    status::show(StatusReportData {
+        activity: current,
+        today,
+        current_week,
+        current_month,
+        project: filter.project,
+    });
+
+    Ok(())
+}

--- a/src/data/filter.rs
+++ b/src/data/filter.rs
@@ -1,6 +1,6 @@
 use crate::data::activity::Activity;
 
-use chrono::{Datelike, Duration, Local, NaiveDate};
+use chrono::{Datelike, Duration, NaiveDate};
 
 pub struct Filters {}
 
@@ -8,24 +8,113 @@ impl Filters {
     pub fn active(activity: &&Activity) -> bool {
         !activity.is_stopped()
     }
-    pub fn today() -> impl Fn(&&Activity) -> bool {
-        let today = Local::now().naive_local().date();
+    pub fn today(today: NaiveDate) -> impl Fn(&&Activity) -> bool {
         move |activity: &&Activity| activity.start.date() == today
     }
-    pub fn current_week() -> impl Fn(&&Activity) -> bool {
-        let today = Local::now().naive_local().date();
+    pub fn current_week(today: NaiveDate) -> impl Fn(&&Activity) -> bool {
         let from_date = today - Duration::days(i64::from(today.weekday().num_days_from_monday()));
         let to_date = today;
         move |activity: &&Activity| {
             activity.start.date() >= from_date && activity.start.date() <= to_date
         }
     }
-    pub fn current_month() -> impl Fn(&&Activity) -> bool {
-        let today = Local::now().naive_local().date();
+    pub fn current_month(today: NaiveDate) -> impl Fn(&&Activity) -> bool {
         let from_date = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap();
         let to_date = today;
         move |activity: &&Activity| {
             activity.start.date() >= from_date && activity.start.date() <= to_date
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::NaiveDateTime;
+
+    use crate::data::activity;
+
+    use super::*;
+
+    #[test]
+    fn filter_active() {
+        let activities = data();
+        let res: Vec<&Activity> = activities.iter().filter(Filters::active).collect();
+        assert_eq!(res.len(), 1);
+        assert_eq!(res.first().unwrap().description.as_str(), "d4");
+    }
+
+    #[test]
+    fn filter_today() {
+        let now = date(2024, 3, 19);
+        let activities = data();
+        let res: Vec<&Activity> = activities
+            .iter()
+            .filter(Filters::today(now.date()))
+            .collect();
+        assert_eq!(res.len(), 2);
+        assert_eq!(res.first().unwrap().description.as_str(), "d3");
+    }
+
+    #[test]
+    fn filter_current_week() {
+        let now = date(2024, 3, 19);
+        let activities = data();
+        let res: Vec<&Activity> = activities
+            .iter()
+            .filter(Filters::current_week(now.date()))
+            .collect();
+        assert_eq!(res.len(), 3);
+        assert_eq!(res.first().unwrap().description.as_str(), "d2");
+    }
+
+    #[test]
+    fn filter_current_month() {
+        let now = date(2024, 3, 19);
+        let activities = data();
+        let res: Vec<&Activity> = activities
+            .iter()
+            .filter(Filters::current_month(now.date()))
+            .collect();
+        assert_eq!(res.len(), 4);
+        assert_eq!(res.first().unwrap().description.as_str(), "d1");
+    }
+
+    fn data() -> Vec<Activity> {
+        let a0 = activity::Activity {
+            project: "p1".to_string(),
+            description: "d0".to_string(),
+            start: date(2024, 2, 11),
+            end: Some(date(2024, 2, 11) + Duration::hours(2)),
+        };
+        let a1 = activity::Activity {
+            project: "p1".to_string(),
+            description: "d1".to_string(),
+            start: date(2024, 3, 11),
+            end: Some(date(2024, 3, 11) + Duration::hours(2)),
+        };
+        let a2 = activity::Activity {
+            project: "p1".to_string(),
+            description: "d2".to_string(),
+            start: date(2024, 3, 18),
+            end: Some(date(2024, 3, 18) + Duration::hours(2)),
+        };
+        let a3 = activity::Activity {
+            project: "p1".to_string(),
+            description: "d3".to_string(),
+            start: date(2024, 3, 19),
+            end: Some(date(2024, 3, 19) + Duration::hours(2)),
+        };
+        let a4 = activity::Activity {
+            project: "p1".to_string(),
+            description: "d4".to_string(),
+            start: date(2024, 3, 19),
+            end: None,
+        };
+        return vec![a0, a1, a2, a3, a4];
+    }
+
+    fn date(year: i32, month: u32, day: u32) -> NaiveDateTime {
+        let date = NaiveDate::from_ymd_opt(year, month, day).unwrap();
+        return NaiveDateTime::new(date, chrono::NaiveTime::from_hms_opt(10, 0, 0).unwrap());
     }
 }

--- a/src/data/filter.rs
+++ b/src/data/filter.rs
@@ -1,0 +1,31 @@
+use crate::data::activity::Activity;
+
+use chrono::{Datelike, Duration, Local, NaiveDate};
+
+pub struct Filters {}
+
+impl Filters {
+    pub fn active(activity: &&Activity) -> bool {
+        !activity.is_stopped()
+    }
+    pub fn today() -> impl Fn(&&Activity) -> bool {
+        let today = Local::now().naive_local().date();
+        move |activity: &&Activity| activity.start.date() == today
+    }
+    pub fn current_week() -> impl Fn(&&Activity) -> bool {
+        let today = Local::now().naive_local().date();
+        let from_date = today - Duration::days(i64::from(today.weekday().num_days_from_monday()));
+        let to_date = today;
+        move |activity: &&Activity| {
+            activity.start.date() >= from_date && activity.start.date() <= to_date
+        }
+    }
+    pub fn current_month() -> impl Fn(&&Activity) -> bool {
+        let today = Local::now().naive_local().date();
+        let from_date = NaiveDate::from_ymd_opt(today.year(), today.month(), 1).unwrap();
+        let to_date = today;
+        move |activity: &&Activity| {
+            activity.start.date() >= from_date && activity.start.date() <= to_date
+        }
+    }
+}

--- a/src/data/getter.rs
+++ b/src/data/getter.rs
@@ -5,6 +5,7 @@ use wildmatch::WildMatch;
 use crate::data::activity;
 use crate::data::activity::Activity;
 use crate::data::bartib_file;
+use crate::data::filter::Filters;
 
 pub struct ActivityFilter<'a> {
     pub number_of_activities: Option<usize>,
@@ -54,7 +55,7 @@ fn get_descriptions_and_projects_from_activities<'a>(
 #[must_use]
 pub fn get_running_activities(file_content: &[bartib_file::Line]) -> Vec<&activity::Activity> {
     get_activities(file_content)
-        .filter(|activity| !activity.is_stopped())
+        .filter(Filters::active)
         .collect()
 }
 

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,5 +1,6 @@
 pub mod activity;
 pub mod bartib_file;
+pub mod filter;
 pub mod getter;
 pub mod processor;
 pub mod round_util;

--- a/src/data/processor.rs
+++ b/src/data/processor.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use chrono::Duration;
 
 use crate::data::activity;
@@ -7,6 +8,17 @@ pub type ProcessorList = Vec<Box<dyn ActivityProcessor>>;
 
 pub trait ActivityProcessor {
     fn process(&self, activity: &activity::Activity) -> activity::Activity;
+}
+
+pub struct StatusReportData<'a> {
+    pub activity: Option<&'a activity::Activity>,
+    pub project: Option<&'a str>,
+    pub today: Duration,
+    pub current_week: Duration,
+    pub current_month: Duration,
+}
+pub trait StatusReportWriter {
+    fn process<'a>(&self, data: &'a StatusReportData) -> Result<()>;
 }
 
 pub struct RoundProcessor {

--- a/src/data/processor.rs
+++ b/src/data/processor.rs
@@ -18,7 +18,7 @@ pub struct StatusReportData<'a> {
     pub current_month: Duration,
 }
 pub trait StatusReportWriter {
-    fn process<'a>(&self, data: &'a StatusReportData) -> Result<()>;
+    fn process(&self, data: &StatusReportData) -> Result<()>;
 }
 
 pub struct RoundProcessor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,4 @@ pub mod conf;
 pub mod controller;
 pub mod data;
 
-mod view;
+pub mod view;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
+use std::borrow::Borrow;
+
 use anyhow::{bail, Context, Result};
+use bartib::view::status::StatusReport;
 use chrono::{Datelike, Duration, Local, NaiveDate, NaiveTime};
 use clap::{crate_version, App, AppSettings, Arg, ArgMatches, SubCommand};
 
@@ -348,7 +351,8 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
         ("status", Some(sub_m)) => {
             let filter = create_filter_for_arguments(sub_m);
             let processors = create_processors_for_arguments(sub_m);
-            bartib::controller::status::show_status(file_name, filter, processors)
+            let writer = create_status_writer(sub_m);
+            bartib::controller::status::show_status(file_name, filter, processors, writer.borrow())
         }
         _ => bail!("Unknown command"),
     }
@@ -362,6 +366,11 @@ fn create_processors_for_arguments(sub_m: &ArgMatches) -> processor::ProcessorLi
     }
 
     processors
+}
+
+fn create_status_writer(_sub_m: &ArgMatches) -> Box<dyn processor::StatusReportWriter> {
+    let result = StatusReport {};
+    Box::new(result)
 }
 
 fn create_filter_for_arguments<'a>(sub_m: &'a ArgMatches) -> ActivityFilter<'a> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -247,6 +247,19 @@ fn main() -> Result<()> {
         )
         .subcommand(SubCommand::with_name("check").about("checks file and reports parsing errors"))
         .subcommand(SubCommand::with_name("sanity").about("checks sanity of bartib log"))
+        .subcommand(
+            SubCommand::with_name("status")
+                .about("shows current status and time reports for today, current week, and current month")
+                .arg(
+                    Arg::with_name("project")
+                        .short("p")
+                        .long("project")
+                        .value_name("PROJECT")
+                        .help("show status for this project only")
+                        .takes_value(true)
+                        .required(false),
+                ),
+        )
         .get_matches();
 
     let file_name = matches.value_of("file")
@@ -332,6 +345,11 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
         }
         ("check", Some(_)) => bartib::controller::list::check(file_name),
         ("sanity", Some(_)) => bartib::controller::list::sanity_check(file_name),
+        ("status", Some(sub_m)) => {
+            let filter = create_filter_for_arguments(sub_m);
+            let processors = create_processors_for_arguments(sub_m);
+            bartib::controller::status::show_status(file_name, filter, processors)
+        }
         _ => bail!("Unknown command"),
     }
 }

--- a/src/view/mod.rs
+++ b/src/view/mod.rs
@@ -1,4 +1,5 @@
 pub mod format_util;
 pub mod list;
 pub mod report;
+pub mod status;
 pub mod table;

--- a/src/view/status.rs
+++ b/src/view/status.rs
@@ -1,0 +1,141 @@
+use std::fmt;
+
+use chrono::Duration;
+use nu_ansi_term::{Color, Style};
+
+use crate::conf;
+use crate::data::activity;
+use crate::view::format_util;
+
+pub struct StatusReportData<'a> {
+    pub activity: Option<&'a activity::Activity>,
+    pub project: Option<&'a str>,
+    pub today: Duration,
+    pub current_week: Duration,
+    pub current_month: Duration,
+}
+
+struct Report<'a> {
+    data: StatusReportData<'a>,
+}
+
+impl<'a> Report<'a> {
+    fn new(data: StatusReportData<'a>) -> Report<'a> {
+        Report { data }
+    }
+}
+
+impl<'a> fmt::Display for Report<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut longest_line = 30;
+        let terminal_width = term_size::dimensions_stdout().map_or(conf::DEFAULT_WIDTH, |d| d.0);
+
+        if terminal_width <= longest_line {
+            longest_line = terminal_width;
+        }
+
+        print_title(f, self.data.project)?;
+        print_activity(f, self.data.activity, self.data.project)?;
+        print_duration(f, "Today", self.data.today, longest_line)?;
+        print_duration(f, "Current week", self.data.current_week, longest_line)?;
+        print_duration(f, "Current month", self.data.current_month, longest_line)?;
+
+        Ok(())
+    }
+}
+
+pub fn show(data: StatusReportData) {
+    let report = Report::new(data);
+    println!("{report}");
+}
+
+fn print_duration(
+    f: &mut fmt::Formatter<'_>,
+    name: &str,
+    total_duration: Duration,
+    line_width: usize,
+) -> fmt::Result {
+    write(f, " ", Style::new().italic())?;
+    write_period(f, name, line_width, Style::new().italic().dimmed())?;
+    write(
+        f,
+        format_util::format_duration(&total_duration).as_str(),
+        Style::new().bold(),
+    )?;
+    write(f, "\n", Style::new().italic())?;
+    Ok(())
+}
+
+fn print_activity(
+    f: &mut fmt::Formatter<'_>,
+    activity: Option<&activity::Activity>,
+    project: Option<&str>,
+) -> fmt::Result {
+    let activity_style = Color::Green.bold();
+    let project_style = Style::new().italic();
+    match activity {
+        Some(activity) => {
+            write(f, "\n  NOW: ", Style::new().italic().dimmed())?;
+            write(f, activity.description.as_str(), activity_style)?;
+            if let Some(pr_str) = project {
+                write(f, " on ", Style::new().italic().dimmed())?;
+                write(f, pr_str, project_style)?;
+            };
+            write(f, " ...... ", Style::new().dimmed())?;
+            write(
+                f,
+                format_util::format_duration(&activity.get_duration()).as_str(),
+                Style::new().bold(),
+            )?;
+            write(f, "\n\n", Style::new().dimmed())?;
+        }
+        None => {
+            write(f, "\n  NOW: ", Style::new().italic().dimmed())?;
+            write(f, " NO Activity\n\n", Style::new().bold())?;
+        }
+    }
+    Ok(())
+}
+
+fn print_title(f: &mut fmt::Formatter<'_>, project: Option<&str>) -> fmt::Result {
+    match project {
+        Some(project) => {
+            write(f, "\n =======", Style::new().dimmed())?;
+            write(f, " Status for project: ", Style::new().italic())?;
+            write(f, project, Style::new().bold())?;
+        }
+        None => {
+            write(f, "\n =======", Style::new().dimmed())?;
+            write(f, " Status for ", Style::new().italic())?;
+            write(f, "ALL", Style::new().bold())?;
+            write(f, " projects ", Style::new().italic())?;
+        }
+    }
+    write(f, " ======= \n", Style::new().dimmed())?;
+    Ok(())
+}
+
+fn write(f: &mut fmt::Formatter<'_>, text: &str, style: Style) -> fmt::Result {
+    write!(
+        f,
+        "{prefix}{text}{suffix}",
+        prefix = style.prefix(),
+        suffix = style.infix(Style::new())
+    )?;
+    Ok(())
+}
+
+fn write_period(
+    f: &mut fmt::Formatter<'_>,
+    text: &str,
+    line_width: usize,
+    style: Style,
+) -> fmt::Result {
+    write!(
+        f,
+        "{prefix} {text:.<line_width$} {suffix}",
+        prefix = style.prefix(),
+        suffix = style.infix(Style::new())
+    )?;
+    Ok(())
+}

--- a/src/view/status.rs
+++ b/src/view/status.rs
@@ -197,7 +197,7 @@ mod tests {
 <>[3m <>[2;3m Current week.................. <>[1m5h 00m<>[3m
 <>[3m <>[2;3m Current month................. <>[1m10h 00m<>[3m
 \u{1b}[0m";
-       
+
         let res = data.to_string();
 
         assert_eq!(clean(res.as_str()), clean(expected));
@@ -228,7 +228,7 @@ mod tests {
 <>[3m <>[2;3m Current week.................. <>[1m5h 00m<>[3m
 <>[3m <>[2;3m Current month................. <>[1m10h 00m<>[3m
 \u{1b}[0m";
-       
+
         let res = data.to_string();
 
         assert_eq!(clean(res.as_str()), clean(expected));

--- a/src/view/status.rs
+++ b/src/view/status.rs
@@ -71,15 +71,13 @@ fn print_activity(
     activity: Option<&activity::Activity>,
     project: Option<&str>,
 ) -> fmt::Result {
-    let activity_style = Color::Green.bold();
-    let project_style = Style::new().italic();
     match activity {
         Some(activity) => {
             write(f, "\n  NOW: ", Style::new().italic().dimmed())?;
-            write(f, activity.description.as_str(), activity_style)?;
-            if let Some(pr_str) = project {
+            write(f, activity.description.as_str(), Color::Green.bold())?;
+            if project.is_none() {
                 write(f, " on ", Style::new().italic().dimmed())?;
-                write(f, pr_str, project_style)?;
+                write(f, &activity.project, Style::new().italic())?;
             };
             write(f, " ...... ", Style::new().dimmed())?;
             write(

--- a/src/view/status.rs
+++ b/src/view/status.rs
@@ -3,50 +3,30 @@ use std::fmt;
 use chrono::Duration;
 use nu_ansi_term::{Color, Style};
 
-use crate::conf;
 use crate::data::activity;
+use crate::data::processor::{StatusReportData, StatusReportWriter};
 use crate::view::format_util;
 
-pub struct StatusReportData<'a> {
-    pub activity: Option<&'a activity::Activity>,
-    pub project: Option<&'a str>,
-    pub today: Duration,
-    pub current_week: Duration,
-    pub current_month: Duration,
-}
+pub struct StatusReport {}
 
-struct Report<'a> {
-    data: StatusReportData<'a>,
-}
-
-impl<'a> Report<'a> {
-    fn new(data: StatusReportData<'a>) -> Report<'a> {
-        Report { data }
-    }
-}
-
-impl<'a> fmt::Display for Report<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut longest_line = 30;
-        let terminal_width = term_size::dimensions_stdout().map_or(conf::DEFAULT_WIDTH, |d| d.0);
-
-        if terminal_width <= longest_line {
-            longest_line = terminal_width;
-        }
-
-        print_title(f, self.data.project)?;
-        print_activity(f, self.data.activity, self.data.project)?;
-        print_duration(f, "Today", self.data.today, longest_line)?;
-        print_duration(f, "Current week", self.data.current_week, longest_line)?;
-        print_duration(f, "Current month", self.data.current_month, longest_line)?;
-
+impl StatusReportWriter for StatusReport {
+    fn process<'a>(&self, data: &'a StatusReportData) -> anyhow::Result<()> {
+        println!("{data}");
         Ok(())
     }
 }
 
-pub fn show(data: StatusReportData) {
-    let report = Report::new(data);
-    println!("{report}");
+impl<'a> fmt::Display for StatusReportData<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let longest_line = 30;
+        print_title(f, self.project)?;
+        print_activity(f, self.activity, self.project)?;
+        print_duration(f, "Today", self.today, longest_line)?;
+        print_duration(f, "Current week", self.current_week, longest_line)?;
+        print_duration(f, "Current month", self.current_month, longest_line)?;
+
+        Ok(())
+    }
 }
 
 fn print_duration(


### PR DESCRIPTION
### What

I need/want to track the current working status for today, current week, and month. So I added a command to act like a `git status`, or some kind of a dashboard.

### New command
```bash
watch -c bartib status -p project1
# or for tracking all projects
watch -c bartib status 
```
![image](https://github.com/nikolassv/bartib/assets/391159/aced80c6-b664-4f1a-a4bd-1abe70fd8177)

### Done:
- added a new `status` command, with allowed parameter `--project`
- added unit tests
- tried to separate a controller from a view: https://github.com/nikolassv/bartib/pull/26#issuecomment-1597297303. Could be easilly extended to output `json` or `csv` by writting a new view.

Thank you. 
