### PR TITLE
feat: implement search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Subcommand `search` to search the list of last activities for terms (thanks to [@Pyxels](https://github.com/Pyxels))
 - Subcommand `status` to display the total duration of activities today, in the current week and in the current month (thanks to [@airenas](https://github.com/airenas))
 
 ## [1.1.0] - 2024-02-29

--- a/README.md
+++ b/README.md
@@ -282,6 +282,8 @@ bartib list --date 2021-09-03    # list activities on a given day
 bartib list --from 2021-09-01 --to 2021-09-05    # list activities in a given time range
 bartib list --project "The most exciting project"    # list activities for a given project
 bartib list --round 15m # rounds the start and end time to the nearest duration. Durations can be in minutes or hours. E.g. 15m or 4h
+
+bartib search    # search all descriptions and projects for a specific term
 ```
 
 ### Edit activities

--- a/README.md
+++ b/README.md
@@ -283,7 +283,8 @@ bartib list --from 2021-09-01 --to 2021-09-05    # list activities in a given ti
 bartib list --project "The most exciting project"    # list activities for a given project
 bartib list --round 15m # rounds the start and end time to the nearest duration. Durations can be in minutes or hours. E.g. 15m or 4h
 
-bartib search    # search all descriptions and projects for a specific term
+bartib search "exiting"   # search all descriptions and projects for a specific term
+bartib search "e*t?ng"   # use '?' and '*' as wildcards
 ```
 
 ### Edit activities

--- a/src/controller/list.rs
+++ b/src/controller/list.rs
@@ -197,3 +197,26 @@ pub fn list_last_activities(file_name: &str, number: usize) -> Result<()> {
 
     Ok(())
 }
+
+// searches for the term in descriptions and projects
+pub fn search(file_name: &str, search_term: Option<&str>) -> Result<()> {
+    let search_term = search_term.unwrap_or("");
+    let file_content = bartib_file::get_file_content(file_name)?;
+
+    let descriptions_and_projects: Vec<(&String, &String)> =
+        getter::get_descriptions_and_projects(&file_content);
+    let matches: Vec<(usize, &(&String, &String))> = descriptions_and_projects
+        .iter()
+        .rev()
+        .enumerate()
+        .rev()
+        .filter(|(_index, (desc, proj))| {
+            desc.to_lowercase().contains(&search_term.to_lowercase())
+                || proj.to_lowercase().contains(&search_term.to_lowercase())
+        })
+        .collect();
+
+    list::list_descriptions_and_projects_with_index(&matches, "No matching activities found");
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,6 +258,16 @@ fn main() -> Result<()> {
         )
         .subcommand(SubCommand::with_name("check").about("checks file and reports parsing errors"))
         .subcommand(SubCommand::with_name("sanity").about("checks sanity of bartib log"))
+        .subcommand(SubCommand::with_name("search").about("search for existing descriptions and projects")
+                .arg(
+                    Arg::with_name("search_term")
+                        .value_name("SEARCH_TERM")
+                        .help("the search term")
+                        .required(false)
+                        .takes_value(true)
+                        .default_value("''"),
+                ),
+        )
         .subcommand(
             SubCommand::with_name("status")
                 .about("shows current status and time reports for today, current week, and current month")
@@ -358,6 +368,10 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
         }
         ("check", Some(_)) => bartib::controller::list::check(file_name),
         ("sanity", Some(_)) => bartib::controller::list::sanity_check(file_name),
+        ("search", Some(sub_m)) => {
+            let search_term = sub_m.value_of("search_term");
+            bartib::controller::list::search(file_name, search_term)
+        }
         ("status", Some(sub_m)) => {
             let filter = create_filter_for_arguments(sub_m);
             let processors = create_processors_for_arguments(sub_m);

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,7 +263,7 @@ fn main() -> Result<()> {
                     Arg::with_name("search_term")
                         .value_name("SEARCH_TERM")
                         .help("the search term")
-                        .required(false)
+                        .required(true)
                         .takes_value(true)
                         .default_value("''"),
                 ),

--- a/src/view/list.rs
+++ b/src/view/list.rs
@@ -116,40 +116,52 @@ pub fn list_running_activities(activities: &[&activity::Activity]) {
     }
 }
 
-// display a list of projects and descriptions with index number
+// display a list of projects and descriptions with generated index number
 pub fn list_descriptions_and_projects(descriptions_and_projects: &[(&String, &String)]) {
+    list_descriptions_and_projects_with_index(
+        &descriptions_and_projects
+            .iter()
+            .rev()
+            .enumerate()
+            .rev()
+            .collect::<Vec<_>>(),
+        "No activities have been tracked yet",
+    )
+}
+
+// display a list of projects ands descriptions with custom indexes
+pub fn list_descriptions_and_projects_with_index(
+    descriptions_and_projects: &[(usize, &(&String, &String))],
+    zero_length_error: &str,
+) {
     if descriptions_and_projects.is_empty() {
-        println!("No activities have been tracked yet");
-    } else {
-        let mut descriptions_and_projects_table = table::Table::new(vec![
-            table::Column {
-                label: " # ".to_string(),
-                wrap: table::Wrap::NoWrap,
-            },
-            table::Column {
-                label: "Description".to_string(),
-                wrap: table::Wrap::Wrap,
-            },
-            table::Column {
-                label: "Project".to_string(),
-                wrap: table::Wrap::Wrap,
-            },
-        ]);
-
-        let mut i = descriptions_and_projects.len();
-
-        for (description, project) in descriptions_and_projects {
-            i = i.saturating_sub(1);
-
-            descriptions_and_projects_table.add_row(table::Row::new(vec![
-                format!("[{}]", i),
-                (*description).to_string(),
-                (*project).to_string(),
-            ]));
-        }
-
-        println!("\n{descriptions_and_projects_table}");
+        println!("{zero_length_error}");
+        return;
     }
+    let mut descriptions_and_projects_table = table::Table::new(vec![
+        table::Column {
+            label: " # ".to_string(),
+            wrap: table::Wrap::NoWrap,
+        },
+        table::Column {
+            label: "Description".to_string(),
+            wrap: table::Wrap::Wrap,
+        },
+        table::Column {
+            label: "Project".to_string(),
+            wrap: table::Wrap::Wrap,
+        },
+    ]);
+
+    for (index, (description, project)) in descriptions_and_projects {
+        descriptions_and_projects_table.add_row(table::Row::new(vec![
+            format!("[{}]", index),
+            (*description).to_string(),
+            (*project).to_string(),
+        ]));
+    }
+
+    println!("\n{descriptions_and_projects_table}");
 }
 
 // create a row for a activity


### PR DESCRIPTION
This adds the `search` subcommand to search (case-insensitive) for strings in the descriptions and projects. 

## Problem
I found myself looking for descriptions to continue that weren't in the last 10 and I didn't know the exact wording of. Before, I usually opened the bartib file and searched there.

## Solution
One can use `bartib search <TERM>` to search for a string in the description/project. All description/project pairs are returned that contain said `<TERM>`.

## Examples
<details>
  <summary>Example Images</summary>

![image](https://github.com/nikolassv/bartib/assets/39232833/c7db403a-e19a-499f-a5d4-027a992e7102)

![image](https://github.com/nikolassv/bartib/assets/39232833/c10339a3-c205-467a-b6d9-ddfc8e074c8f)

![image](https://github.com/nikolassv/bartib/assets/39232833/9919d540-e1e8-4d58-93b3-0d21d12fff48)


</details>

## Notes

I had to somewhat refactor the `list_descriptions_and_projects` function to avoid code repetition, please let me know if you'd like this handled differently.

_Not sure if this is something you'd like, feel free to close/change._