### PR TITLE
feat: print projects without quotes

### DIFF
--- a/src/controller/list.rs
+++ b/src/controller/list.rs
@@ -163,7 +163,7 @@ pub fn check(file_name: &str) -> Result<()> {
 }
 
 // lists all projects
-pub fn list_projects(file_name: &str, current: bool) -> Result<()> {
+pub fn list_projects(file_name: &str, current: bool, no_quotes: bool) -> Result<()> {
     let file_content = bartib_file::get_file_content(file_name)?;
 
     let mut all_projects: Vec<&String> = getter::get_activities(&file_content)
@@ -175,7 +175,11 @@ pub fn list_projects(file_name: &str, current: bool) -> Result<()> {
     all_projects.dedup();
 
     for project in all_projects {
-        println!("\"{project}\"");
+        if no_quotes {
+            println!("{project}");
+        } else {
+            println!("\"{project}\"");
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,9 +342,11 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
             let processors = create_processors_for_arguments(sub_m);
             bartib::controller::report::show_report(file_name, filter, processors)
         }
-        ("projects", Some(sub_m)) => {
-            bartib::controller::list::list_projects(file_name, sub_m.is_present("current"), sub_m.is_present("no-quotes"))
-        }
+        ("projects", Some(sub_m)) => bartib::controller::list::list_projects(
+            file_name,
+            sub_m.is_present("current"),
+            sub_m.is_present("no-quotes"),
+        ),
         ("last", Some(sub_m)) => {
             let number = get_number_argument_or_ignore(sub_m.value_of("number"), "-n/--number")
                 .unwrap_or(10);

--- a/src/main.rs
+++ b/src/main.rs
@@ -234,6 +234,14 @@ fn main() -> Result<()> {
                         .help("prints currently running projects only")
                         .takes_value(false)
                         .required(false),
+                )
+                .arg(
+                    Arg::with_name("no-quotes")
+                        .short("n")
+                        .long("no-quotes")
+                        .help("prints projects without quotes")
+                        .takes_value(false)
+                        .required(false),
                 ),
         )
         .subcommand(
@@ -335,7 +343,7 @@ fn run_subcommand(matches: &ArgMatches, file_name: &str) -> Result<()> {
             bartib::controller::report::show_report(file_name, filter, processors)
         }
         ("projects", Some(sub_m)) => {
-            bartib::controller::list::list_projects(file_name, sub_m.is_present("current"))
+            bartib::controller::list::list_projects(file_name, sub_m.is_present("current"), sub_m.is_present("no-quotes"))
         }
         ("last", Some(sub_m)) => {
             let number = get_number_argument_or_ignore(sub_m.value_of("number"), "-n/--number")


### PR DESCRIPTION
resolves #36 

Adds an option to print projects without quotes, e.g.

- long argument: `bartib projects --no-quotes`
- short argument `bartib projects -n`

results in:
```
Project1
Project2
```

instead of

```
"Project1"
"Project2"
```
