### PR TITLE
Introduce `second-precision` feature to Bartib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Feature `second-precision` to build bartib with the ability to track activities to the second (thank to [@johnDeSilencio](https://github.com/johnDeSilencio))
 - Subcommand `search` to search the list of last activities for terms (thanks to [@Pyxels](https://github.com/Pyxels))
 - Subcommand `status` to display the total duration of activities today, in the current week and in the current month (thanks to [@airenas](https://github.com/airenas))
 - Option `--no-quotes` to `project` to suppres quotes in the projects list (thanks to [@defigli](https://github.com/defigli))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,12 +2,12 @@
 name = "bartib"
 version = "1.1.0"
 authors = ["Nikolas Schmidt-Voigt <nikolas.schmidt-voigt@posteo.de>"]
+edition = "2018"
 description = "A simple timetracker for the command line"
+readme = "README.md"
 homepage = "https://github.com/nikolassv/bartib"
 repository = "https://github.com/nikolassv/bartib"
-edition = "2018"
 license = "GPL-3.0-or-later"
-readme = "README.md"
 keywords = ["cli"]
 categories = ["command-line-utilities"]
 
@@ -16,21 +16,6 @@ upgrade-guid = "1D8348BE-1D47-4755-8D09-624AF8B092C3"
 path-guid = "BE8CBFAC-1DE6-4B0D-BB4B-C31A85A34AC5"
 license = false
 eula = false
-
-[dependencies]
-chrono = "0.4.0"
-clap = "2.0.0"
-thiserror = "1.0.0"
-anyhow = "1.0.0"
-nu-ansi-term = "0.46.0"
-term_size = "0.3.0"
-textwrap = "0.16.0"
-wildmatch = "2.3.0"
-
-# The profile that 'cargo dist' will build with
-[profile.dist]
-inherits = "release"
-lto = "thin"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]
@@ -41,6 +26,26 @@ ci = ["github"]
 # The installers to generate for each app
 installers = ["shell", "powershell", "msi"]
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = [
+  "aarch64-apple-darwin",
+  "x86_64-apple-darwin",
+  "x86_64-unknown-linux-gnu",
+  "x86_64-pc-windows-msvc",
+]
 # Publish jobs to run in CI
 pr-run-mode = "upload"
+
+[dependencies]
+anyhow = "1.0.0"
+chrono = "0.4.0"
+clap = "2.0.0"
+nu-ansi-term = "0.46.0"
+term_size = "0.3.0"
+textwrap = "0.16.0"
+thiserror = "1.0.0"
+wildmatch = "2.3.0"
+
+# The profile that 'cargo dist' will build with
+[profile.dist]
+inherits = "release"
+lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ textwrap = "0.16.0"
 thiserror = "1.0.0"
 wildmatch = "2.3.0"
 
+[features]
+# Timestamps are recorded with second precision instead of the default minute precision
+second-precision = []
+
 # The profile that 'cargo dist' will build with
 [profile.dist]
 inherits = "release"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Bartib is an easy to use time tracking tool for the command line. It saves a log
       - [Via homebrew](#via-homebrew)
       - [Via apk (Alpine Linux)](#via-apk-alpine-linux)
     - [How to build Bartib](#how-to-build-bartib)
+      - [Precision](#precision)
     - [How to define in which file to save the log of your activities](#how-to-define-in-which-file-to-save-the-log-of-your-activities)
     - [How to edit or delete tracked activities](#how-to-edit-or-delete-tracked-activities)
     - [How to activate auto completion](#how-to-activate-auto-completion)
@@ -184,6 +185,14 @@ Bartib is written in rust. You may build it yourself with the help of cargo. Jus
 
 ```bash
 cargo build --release
+```
+
+#### Precision
+
+By default, Bartib measures timestamps in minutes. If you would like to measure timestamps with second precision, you can enable the `second-precision` feature:
+
+```bash
+cargo build --features=second-precision --release
 ```
 
 ### How to define in which file to save the log of your activities

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cargo build --release
 
 #### Precision
 
-By default, Bartib measures timestamps in minutes. If you would like to measure timestamps with second precision, you can enable the `second-precision` feature:
+By default, Bartib records timestamps in minutes. If you would like to record timestamps with second precision, you can enable the `second-precision` feature:
 
 ```bash
 cargo build --features=second-precision --release

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,15 +1,18 @@
 use chrono::Duration;
 
-#[cfg(feature = "second-precision")]
-pub static FORMAT_DATETIME: &str = "%F %T";
-#[cfg(not(feature = "second-precision"))]
-pub static FORMAT_DATETIME: &str = "%F %R";
+pub static FORMAT_MINUTE_PRECISION_DATETIME: &str = "%F %R";
+pub static FORMAT_SECOND_PRECISION_DATETIME: &str = "%F %T";
 
+#[cfg(not(feature = "second-precision"))]
+pub static FORMAT_DATETIME: &str = FORMAT_MINUTE_PRECISION_DATETIME;
 #[cfg(feature = "second-precision")]
-pub static FORMAT_TIME: &str = "%T";
+pub static FORMAT_DATETIME: &str = FORMAT_SECOND_PRECISION_DATETIME;
+
 #[cfg(not(feature = "second-precision"))]
 pub static FORMAT_TIME: &str = "%R";
+#[cfg(feature = "second-precision")]
 
+pub static FORMAT_TIME: &str = "%T";
 pub static FORMAT_DATE: &str = "%F";
 pub static DEFAULT_WIDTH: usize = usize::MAX;
 pub static REPORT_INDENTATION: usize = 4;

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -1,7 +1,15 @@
 use chrono::Duration;
 
+#[cfg(feature = "second-precision")]
+pub static FORMAT_DATETIME: &str = "%F %T";
+#[cfg(not(feature = "second-precision"))]
 pub static FORMAT_DATETIME: &str = "%F %R";
+
+#[cfg(feature = "second-precision")]
+pub static FORMAT_TIME: &str = "%T";
+#[cfg(not(feature = "second-precision"))]
 pub static FORMAT_TIME: &str = "%R";
+
 pub static FORMAT_DATE: &str = "%F";
 pub static DEFAULT_WIDTH: usize = usize::MAX;
 pub static REPORT_INDENTATION: usize = 4;

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -11,8 +11,8 @@ pub static FORMAT_DATETIME: &str = FORMAT_SECOND_PRECISION_DATETIME;
 #[cfg(not(feature = "second-precision"))]
 pub static FORMAT_TIME: &str = "%R";
 #[cfg(feature = "second-precision")]
-
 pub static FORMAT_TIME: &str = "%T";
+
 pub static FORMAT_DATE: &str = "%F";
 pub static DEFAULT_WIDTH: usize = usize::MAX;
 pub static REPORT_INDENTATION: usize = 4;

--- a/src/data/activity.rs
+++ b/src/data/activity.rs
@@ -130,7 +130,11 @@ fn parse_timepart(time_part: &str) -> Result<NaiveDateTime, ActivityError> {
                 conf::FORMAT_SECOND_PRECISION_DATETIME,
             ) {
                 Ok(datetime) => {
-                    // Successfully parsed timestamp. Round to the nearest minute
+                    // Successfully parsed timestamp. Notify the user about the mismatch
+                    // and round to the nearest minute
+                    eprintln!("WARNING: Bartib log encountered timestamps with minute precision.");
+                    eprintln!("This version of Bartib has been compiled with second precision");
+
                     let datetime = datetime
                         .duration_round(Duration::minutes(1))
                         .map_err(|_| ActivityError::DateTimeParseError)?;
@@ -151,10 +155,14 @@ fn parse_timepart(time_part: &str) -> Result<NaiveDateTime, ActivityError> {
             // Presume that the timestamp has minute-precision and that is the cause of the error
             match NaiveDateTime::parse_from_str(
                 time_part.trim(),
-                conf::FORMAT_SECOND_PRECISION_DATETIME,
+                conf::FORMAT_MINUTE_PRECISION_DATETIME,
             ) {
                 Ok(datetime) => {
-                    // Successfully parsed timestamp. Set seconds to zero
+                    // Successfully parsed timestamp. Notify the user about the mismatch
+                    // and set seconds to zero
+                    eprintln!("WARNING: Bartib log encountered timestamps with minute precision.");
+                    eprintln!("This version of Bartib has been compiled with second precision");
+
                     let datetime = datetime
                         .with_second(0)
                         .ok_or(ActivityError::DateTimeParseError)?;

--- a/src/data/activity.rs
+++ b/src/data/activity.rs
@@ -484,4 +484,62 @@ mod tests {
         let t = Activity::from_str("asb - 2021- | project");
         assert!(matches!(t, Err(ActivityError::DateTimeParseError)));
     }
+
+    #[test]
+    #[cfg(not(feature = "second-precision"))]
+    fn from_str_second_precision_encountered_when_minute_precision_expected() {
+        let t = Activity::from_str(
+            "2021-02-16 16:14:53 - 2021-02-16 18:23:17 | test project | test description",
+        )
+        .unwrap();
+
+        assert_eq!(t.start.date().year(), 2021);
+        assert_eq!(t.start.date().month(), 2);
+        assert_eq!(t.start.date().day(), 16);
+
+        assert_eq!(t.start.time().hour(), 16);
+        assert_eq!(t.start.time().minute(), 15);
+        assert_eq!(t.start.time().second(), 0);
+
+        assert_ne!(t.end, None);
+
+        let end = t.end.unwrap();
+
+        assert_eq!(end.date().year(), 2021);
+        assert_eq!(end.date().month(), 2);
+        assert_eq!(end.date().day(), 16);
+
+        assert_eq!(end.time().hour(), 18);
+        assert_eq!(end.time().minute(), 23);
+        assert_eq!(end.time().second(), 0);
+    }
+
+    #[test]
+    #[cfg(feature = "second-precision")]
+    fn from_str_minute_precision_encountered_when_second_precision_expected() {
+        let t = Activity::from_str(
+            "2021-02-16 16:14 - 2021-02-16 18:23 | test project | test description",
+        )
+        .unwrap();
+
+        assert_eq!(t.start.date().year(), 2021);
+        assert_eq!(t.start.date().month(), 2);
+        assert_eq!(t.start.date().day(), 16);
+
+        assert_eq!(t.start.time().hour(), 16);
+        assert_eq!(t.start.time().minute(), 14);
+        assert_eq!(t.start.time().second(), 0);
+
+        assert_ne!(t.end, None);
+
+        let end = t.end.unwrap();
+
+        assert_eq!(end.date().year(), 2021);
+        assert_eq!(end.date().month(), 2);
+        assert_eq!(end.date().day(), 16);
+
+        assert_eq!(end.time().hour(), 18);
+        assert_eq!(end.time().minute(), 23);
+        assert_eq!(end.time().second(), 0);
+    }
 }

--- a/src/view/format_util.rs
+++ b/src/view/format_util.rs
@@ -10,7 +10,10 @@ pub fn format_duration(duration: &Duration) -> String {
     if duration.num_minutes() > 0 {
         duration_string.push_str(&format!("{:0>2}m", duration.num_minutes() % 60));
     } else {
+        #[cfg(not(feature = "second-precision"))]
         duration_string.push_str("<1m");
+        #[cfg(feature = "second-precision")]
+        duration_string.push_str(&format!("{:0>2}s", duration.num_seconds() % 60));
     }
 
     duration_string

--- a/src/view/report.rs
+++ b/src/view/report.rs
@@ -219,7 +219,11 @@ fn get_longest_duration_string(report: &Report) -> Option<usize> {
 fn get_max_option(o1: Option<usize>, o2: Option<usize>) -> Option<usize> {
     if let Some(s1) = o1 {
         if let Some(s2) = o2 {
-            if s1 > s2 { o1 } else { o2 }
+            if s1 > s2 {
+                o1
+            } else {
+                o2
+            }
         } else {
             o1
         }

--- a/src/view/report.rs
+++ b/src/view/report.rs
@@ -219,11 +219,7 @@ fn get_longest_duration_string(report: &Report) -> Option<usize> {
 fn get_max_option(o1: Option<usize>, o2: Option<usize>) -> Option<usize> {
     if let Some(s1) = o1 {
         if let Some(s2) = o2 {
-            if s1 > s2 {
-                o1
-            } else {
-                o2
-            }
+            if s1 > s2 { o1 } else { o2 }
         } else {
             o1
         }


### PR DESCRIPTION
## What?

This PR introduces a `second-precision` feature to Bartib that allows users who compile the binary from source to record timestamps in their log file and perform report calculations with a precision of seconds instead of a precision of minutes, as is the default.

## Why?

I use Bartib in my `post-checkout` git hook so I can capture the amount of time I spend on each branch over the course of the day. Sometimes, I have to flip between branches quickly. I see a lot of the following timestamps in my log file:

```none
2025-06-12 23:24 - 2025-06-12 23:24 | // ...
// ...
2025-06-12 23:28 - 2025-06-12 23:28 | // ...
2025-06-12 23:28 - 2025-06-12 23:28 | // ...
// ...
```

Those logs entries effectively become "lost" minutes, if I am not mistaken. That might not seem like much, but over a period of several months using Bartib, that can amount to potentially hours worth of "lost" minutes.

## How?

I didn't want to alter the default timestamp precision for all users, so I put these changes behind the feature gate `second-precision` and preserved all of the old code.

## Breaking changes?

The only thing that _might_ be considered a breaking change is the changes I made to `data::parse_timepart()`. I added some additional logic to detect if there is a precision mismatch. For example, in the following screenshot, `bartib` was compiled without the `second-precision` flag but has encountered a log with timestamps that have second precision:

![image](https://github.com/user-attachments/assets/a94ca73b-e09e-44f2-a5b7-c3b745f15852)

<details>
  <summary>`bartib_log.txt`</summary>

  ```none
  2025-06-12 23:23:12 - 2025-06-12 23:23:28 | my project | my description
  2025-06-12 23:24:01 - 2025-06-12 23:24:20 | my project | my description
  2025-06-12 23:24:38 - 2025-06-12 23:24:59 | my project | my description
  2025-06-12 23:25:44 - 2025-06-12 23:25:54 | my project | my description
  2025-06-12 23:28:00 - 2025-06-12 23:28:14 | my project | my description
  2025-06-12 23:39:17 - 2025-06-12 23:39:25 | my project | my description
  2025-06-12 23:39:25 | another project | another description
  ```

</details>

---

I want to thank you for all of the hard work you put into this crate! This has got to be one of the best organized crates I've seen yet. I was able to make these changes in less than two hours on a single weekend - and everything worked _on the first try_. I know no higher honor I can given an open source maintainer than that.

Let me know if there are any changes that you'd like me to make! I'm open to feedback :)

Cheers,

- Nick